### PR TITLE
Fix code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes [https://github.com/advanced-security-demo/s-samadi-ghas-demo/security/code-scanning/2](https://github.com/advanced-security-demo/s-samadi-ghas-demo/security/code-scanning/2)

To fix the problem, we need to use SQL parameterization instead of string concatenation to construct the SQL query. This can be achieved by using the `db.Prepare` method with placeholders (`?`) for the user-provided values and then passing those values as arguments to the `stmt.Exec` method. This approach ensures that the user-provided data is safely embedded into the query, preventing SQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
